### PR TITLE
Change default of "Small fields" below the wizard

### DIFF
--- a/Classes/Controller/TableWizardController.php
+++ b/Classes/Controller/TableWizardController.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
- * Controller for the table wizard
+ * Controller for the table wizard - extends the core wizard
  *
  * @author Georg Großberger <georg.grossberger@cyberhouse.at>
  * @license http://opensource.org/licenses/MIT MIT - License
@@ -24,13 +24,25 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 class TableWizardController extends TableController {
 
 	/**
+	 * Initialization of the class
 	 *
-	 * @param array $cfgArr
-	 * @param array $row
-	 * @return string
+	 * @return void
+	 */
+	protected function init() {
+		parent::init();
+		// show textareas or input fields in wizard
+		// »smallFields« parameter (0 = textarea) is set in TCA, »textFields« is a wizard post value
+		$this->inputStyle = (!empty($this->P['params']['smallFields']) || !empty($this->TABLECFG['textFields']))? 1 : 0;
+	}
+
+	/**
+	 * Creates the HTML for the Table Wizard Module
+	 *
+	 * @param array $cfgArr Table config array
+	 * @param array $row Current parent record array
+	 * @return string HTML for the table wizard
 	 */
 	public function getTableHTML($cfgArr, $row) {
-
 		// Make sure we load jQuery
 		$pageRenderer = $this->doc->getPageRenderer();
 		$pageRenderer->loadJquery();
@@ -40,7 +52,7 @@ class TableWizardController extends TableController {
 		$pageRenderer->addCssFile($relPath . 'Stylesheet/TableWizard.css');
 		$pageRenderer->addJsFile($relPath . 'Javascript/TableWizard.js');
 
-		// Generate the table and strip useless stuff
+		// Generate the table markup and strip useless stuff
 		$content = parent::getTableHTML($cfgArr, $row);
 		$content = preg_replace('/ style="width[^"]+"/', '', $content);
 		$content = preg_replace('/<td class="bgColor5">[^' . "\n" . ']+<\/td>/', '', $content);

--- a/Documentation/UserManual.rst
+++ b/Documentation/UserManual.rst
@@ -70,6 +70,10 @@ Here you see how the CSV content is turned into rows and columns. The content of
 
 By default, the option *Small fields* below the wizard is selected. This means the values will be inside single - line fields. Disabling this option, will render textarea fields that allow the useage of linebreaks and larger texts.
 
+To disable the *Small fields* checkbox by default use this TCA setting:
+
+	$TCA['tt_content']['columns']['bodytext']['config']['wizards']['table']['params']['smallFields'] = 0;
+
 .. tip::
 	When using big fields (textarea), be sure to use a **Text Delimiter** option, other than *None*. Otherwise linebreaks in the text will trigger the creation of an additional column which will destroy the table layout.
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -22,3 +22,6 @@
 		table_cellpadding.types.table.disabled = 1
 	}
 ');
+
+// Overwrite default settings in table wizard
+$TCA['tt_content']['columns']['bodytext']['config']['wizards']['table']['params']['smallFields'] = 1;


### PR DESCRIPTION
Enable integrators to set a default value for the
table wizard to use textareas instead of input fields.

Setting this value would switch the current behaviour
of the »small fields« checkbox.

$TCA['tt_content']['columns']['bodytext']['config']['wizards']['table']['params']['smallFields'] = 0;

Refs #1
