### PR TITLE
TYPO3 6.2 Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+*.sublime-*

--- a/Classes/Controller/TableFrontendController.php
+++ b/Classes/Controller/TableFrontendController.php
@@ -77,7 +77,7 @@ class TableFrontendController extends AbstractPlugin {
 		$content = str_replace("\r", '', $this->cObj->data['bodytext']);
 		$rowDelimiter = '\s*' . preg_quote(LF, '/') . '\s*';
 		$fieldWrap = preg_quote($config['fieldWrap'], '/');
-		$columnDelimiter = $config['fieldDelimiter'];
+		$columnDelimiter = preg_quote($config['fieldDelimiter'], '/');
 
 		if (!empty($fieldWrap)) {
 			$rowDelimiter = $fieldWrap . $rowDelimiter . $fieldWrap;

--- a/Documentation/TyposcriptReference.rst
+++ b/Documentation/TyposcriptReference.rst
@@ -4,6 +4,8 @@ Typoscript Reference
 
 The Typoscript template **Better Tables** must be included for this extension to work and the following options to be available.
 
+Please note: If editors choose »default« in the table settings of the content element, then the given TypoScript values are used. You are required to set/check some defaults like »fieldDelimiter«.
+
 Options
 -------
 
@@ -17,7 +19,7 @@ Options
 		string
 
 	Description
-		CSS class selector(s) to add to the table tag.
+		CSS class to add to the table tag.
 
 	Default
 		*None*
@@ -35,7 +37,7 @@ Options
 		If enabled, additional CSS classes will be added to the table, tr and td tags.
 
 	Default
-		no
+		0
 
 .. ..................................
 .. container:: table-row
@@ -54,6 +56,51 @@ Options
 
 	Default
 		1 (htmlSpecialChars)
+
+.. ..................................
+.. container:: table-row
+
+	Property
+		fieldDelimiter
+
+	Data type
+		string
+
+	Description
+		The character which specifies to boundary between separate cells in each line of text
+
+	Default
+		| (Pipe)
+
+.. ..................................
+.. container:: table-row
+
+	Property
+		fieldWrap
+
+	Data type
+		string
+
+	Description
+		Wrapper around the content of a single column. Required if the cell content includes uses special characters.
+
+	Default
+		*None*
+
+.. ..................................
+.. container:: table-row
+
+	Property
+		trimFields
+
+	Data type
+		boolean
+
+	Description
+		Trim the content of a cell of spaces before adding them.
+
+	Default
+		0
 
 .. ..................................
 .. container:: table-row
@@ -87,9 +134,7 @@ Options
 		Has no effect if *headerPosition* is set to an other value than *top*
 
 	Default
-		no
-
-
+		0
 
 Constants
 ---------

--- a/Documentation/UserManual.rst
+++ b/Documentation/UserManual.rst
@@ -40,7 +40,7 @@ Table summary      The content of the summary attribute. A short explanation
                    page
 ================   ===========================================================
 
-For all other settings, please see the `TypoScript Reference`_, because their values are set by Typoscript if the displayed option is *Default*. Changing this will override the value set by Typoscript.
+For all other settings, please see the `TypoScript Reference`_, because their values are set by TypoScript if the displayed option is *Default*. Changing this will override the value set by TypoScript.
 
 .. _TypoScript Reference: TyposcriptReference.rst
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,37 +4,23 @@ $EM_CONF[$_EXTKEY] = array(
 	'title' => 'Better tables',
 	'description' => 'Overrides the default table element with a better, easier to use and modern plugin. Features a JS based wizard, a fluid template and more useable settings.',
 	'category' => 'plugin',
-	'shy' => 0,
-	'dependencies' => '',
-	'conflicts' => '',
-	'priority' => '',
-	'loadOrder' => '',
-	'module' => '',
+	'version' => '0.1.0',
 	'state' => 'beta',
-	'internal' => 0,
 	'uploadfolder' => 0,
 	'createDirs' => '',
-	'modify_tables' => '',
 	'clearCacheOnLoad' => 1,
-	'lockType' => '',
 	'author' => 'Georg Großberger',
 	'author_email' => 'contact@grossberger-ge.org',
 	'author_company' => '',
-	'CGLcompliance' => '',
-	'CGLcompliance_note' => '',
-	'version' => '0.1.0',
 	'constraints' => array(
 		'depends' => array(
-			'php' => '5.3.8-5.5.99',
-			'extbase' => '6.1.0-6.2.99',
-			'fluid' => '6.1.0-6.2.99',
+			'typo3' => '6.1.0-6.2.99',
+			'php' => '5.3.0-5.5.99'
 		),
 		'conflicts' => array(
 		),
 		'suggests' => array(
-		),
-	),
-	'suggests' => array(
+		)
 	),
 );
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -6,11 +6,11 @@
  * the terms of the MIT- / X11 - License                                 *
  *                                                                       */
 
-// Insert our own flexform
+// Overwrite table flexform with our own
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue('*', 'FILE:EXT:' . $_EXTKEY . '/Configuration/FlexForms/plugin_table.xml', 'table');
 
-// Typoscript overrides
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/Typoscript/', 'Better Tables');
+// TypoScript
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript/', 'Better Tables');
 
 // Remove obsolete items from tt_content, eg cellspacing
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('


### PR DESCRIPTION
- Extend docs
- Escape regex characters in field delimiter
- Remove outdated fields from extension config
- Fix path to TypoScript

Refs #2
