### PR TITLE
Enable editor to set column width

### DIFF
--- a/Classes/Controller/TableFrontendController.php
+++ b/Classes/Controller/TableFrontendController.php
@@ -129,6 +129,7 @@ class TableFrontendController extends AbstractPlugin {
 			'headerPosition' => array('acctables_headerpos', 'sDEF'),
 			'cssClasses' => array('acctables_tableclass', 'sDEF'),
 			'additionalCssClasses' => array('acctables_nostyles', 'sDEF'),
+			'colWidth' => array('acctables_colwidth', 'sDEF'),
 			'fieldWrap' => array('tableparsing_quote', 's_parsing'),
 			'fieldDelimiter' => array('tableparsing_delimiter', 's_parsing'),
 			'trimFields' => array('tableparsing_trimfields', 's_parsing'),
@@ -145,6 +146,10 @@ class TableFrontendController extends AbstractPlugin {
 			if (NULL !== $value) {
 				$config[$configField] = $value;
 			}
+		}
+
+		if(!empty($config['colWidth'])) {
+			$config['colWidth'] = GeneralUtility::trimExplode(',', $config['colWidth']);
 		}
 
 		return $config;

--- a/Configuration/FlexForms/plugin_table.xml
+++ b/Configuration/FlexForms/plugin_table.xml
@@ -85,6 +85,7 @@
 							</config>
 						</TCEforms>
 					</acctables_headerpos>
+
 					<acctables_nostyles>
 						<TCEforms>
 							<label>LLL:EXT:css_styled_content/locallang_db.xml:tt_content.tx_cssstyledcontent_acctables_nostyles</label>
@@ -120,6 +121,16 @@
 							</config>
 						</TCEforms>
 					</acctables_tableclass>
+
+					<acctables_colwidth>
+						<TCEforms>
+							<label>LLL:EXT:better_tables/Resources/Private/Language/locallang.xlf:tt_content.colwidth</label>
+							<config>
+								<type>input</type>
+								<size>40</size>
+							</config>
+						</TCEforms>
+					</acctables_colwidth>
 				</el>
 			</ROOT>
 		</sDEF>

--- a/Documentation/UserManual.rst
+++ b/Documentation/UserManual.rst
@@ -30,15 +30,18 @@ Settings
 
 The following two settings can only be set by the content element
 
-================   ===========================================================
-Setting            Meaning
-================   ===========================================================
-Table caption      Insert a caption in the table. This will generate a
-                   caption tag, that works similar to a h1 tag
-Table summary      The content of the summary attribute. A short explanation
-                   of what the table contains. Is not visible on the rendered
-                   page
-================   ===========================================================
+=====================   ===========================================================
+Setting                 Meaning
+=====================   ===========================================================
+Table caption           Insert a caption in the table. This will generate a
+                        caption tag, that works similar to a h1 tag
+Table summary           The content of the summary attribute. A short explanation
+                        of what the table contains. Is not visible on the rendered
+                        page
+Table column width      Optional width of each column in percentage terms.
+                        E.g. “50, 25, 25“ for three columns, or »75« if you would
+                        like to set the width of the first column only
+=====================   ===========================================================
 
 For all other settings, please see the `TypoScript Reference`_, because their values are set by Typoscript if the displayed option is *Default*. Changing this will override the value set by Typoscript.
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -12,6 +12,9 @@
 			<trans-unit id="mode.text">
 				<source>Textarea</source>
 			</trans-unit>
+			<trans-unit id="tt_content.colwidth">
+				<source>Width of each column in percentage terms (e.g. “50, 25, 25“ for three columns)</source>
+			</trans-unit>
 			<trans-unit id="tt_content.trimFields">
 				<source>Trim the cell contents of white spaces</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Table.html
+++ b/Resources/Private/Templates/Table.html
@@ -1,17 +1,24 @@
 {namespace bt=GeorgGrossberger\BetterTables\ViewHelpers}
 
 <table{bt:tableClasses(settings: settings, data:data)}<f:if condition="{settings.summary}"> summary="{settings.summary -> f:format.htmlspecialchars()}"</f:if>>
-<f:if condition="{settings.caption}"><caption>{settings.caption -> f:format.htmlspecialchars()}</caption></f:if>
-	<f:if condition="{header -> f:count()} > 0">
-	<f:if condition="{settings.headerPosition} == 'top'">
-	<thead>
-		<tr{bt:rowClasses(settings: settings, iteration: {index: 0, isFirst: 1, isLast: 1, isOdd: 0})}>
-		<f:for each="{header}" as="cell" iteration="cellIteration">
-			<th{bt:cellClasses(settings: settings, iteration: cellIteration)}>{cell -> bt:cellContent(configuration: settings.cellParseFunc)}</th>
-		</f:for>
-		</tr>
-	</thead>
+	<f:if condition="{settings.caption}"><caption>{settings.caption -> f:format.htmlspecialchars()}</caption></f:if>
+	<f:if condition="{settings.colWidth -> f:count()} > 0">
+		<colgroup>
+			<f:for each="{settings.colWidth}" as="singleColWidth">
+				<col width="{f:if(condition:'{singleColWidth}', then: '{singleColWidth}%', else: '*')}">
+			</f:for>
+		</colgroup>
 	</f:if>
+	<f:if condition="{header -> f:count()} > 0">
+		<f:if condition="{settings.headerPosition} == 'top'">
+			<thead>
+				<tr{bt:rowClasses(settings: settings, iteration: {index: 0, isFirst: 1, isLast: 1, isOdd: 0})}>
+				<f:for each="{header}" as="cell" iteration="cellIteration">
+					<th{bt:cellClasses(settings: settings, iteration: cellIteration)}>{cell -> bt:cellContent(configuration: settings.cellParseFunc)}</th>
+				</f:for>
+				</tr>
+			</thead>
+		</f:if>
 	</f:if>
 	<tbody>
 		<f:for each="{rows}" as="row" iteration="rowIteration">


### PR DESCRIPTION
Add a field to the table flexform to enable
the editor to set the width of table columns.

Use colgroups with percentage values in
table markup to allow most flexibility.
